### PR TITLE
add -onepass option, allowing exit after initial sync

### DIFF
--- a/default.lua
+++ b/default.lua
@@ -120,7 +120,14 @@ default.collect = function
 				agent.target,
 				' finished.'
 			)
-
+            if settings('onepass')
+            then
+                log(
+                    'Normal', 
+                    'onepass config set, exiting'
+                )
+                terminate( 0 )
+            end
 			return 'ok'
 		elseif rc == 'again'
 		then

--- a/default.lua
+++ b/default.lua
@@ -120,14 +120,14 @@ default.collect = function
 				agent.target,
 				' finished.'
 			)
-            if settings('onepass')
-            then
-                log(
-                    'Normal', 
-                    'onepass config set, exiting'
-                )
-                terminate( 0 )
-            end
+			if settings('onepass')
+			then
+				log(
+					'Normal', 
+					'onepass config set, exiting'
+				)
+				terminate( 0 )
+			end
 			return 'ok'
 		elseif rc == 'again'
 		then

--- a/lsyncd.c
+++ b/lsyncd.c
@@ -91,6 +91,7 @@ struct settings settings = {
 	.log_facility = LOG_USER,
 	.log_level    = LOG_NOTICE,
 	.nodaemon     = false,
+	.onepass      = false,
 };
 
 
@@ -1629,6 +1630,10 @@ l_configure( lua_State *L )
 	else if( !strcmp( command, "nodaemon" ) )
 	{
 		settings.nodaemon = true;
+	}
+	else if( !strcmp( command, "onepass" ) )
+	{
+		settings.onepass = true;
 	}
 	else if( !strcmp( command, "logfile" ) )
 	{

--- a/lsyncd.h
+++ b/lsyncd.h
@@ -57,6 +57,7 @@ extern struct settings {
 	int log_facility; // The syslog facility
 	int log_level;    // -1 logs everything, 0 normal mode, LOG_ERROR errors only.
 	bool nodaemon;    // True if Lsyncd shall not daemonize.
+	bool onepass;     // True if Lsyncd should exit after first sync pass
 	char * pidfile;   // If not NULL Lsyncd writes its pid into this file.
 
 } settings;

--- a/lsyncd.lua
+++ b/lsyncd.lua
@@ -75,6 +75,7 @@ local settingsCheckgauge =
 	logfile        = true,
 	pidfile        = true,
 	nodaemon	   = true,
+	onepass 	   = true,
 	statusFile     = true,
 	statusInterval = true,
 	logfacility    = true,
@@ -4614,6 +4615,7 @@ OPTIONS:
   -log    [Category]  Turns on logging for a debug category
   -logfile FILE       Writes log to FILE (DEFAULT: uses syslog)
   -nodaemon           Does not detach and logs to stdout/stderr
+  -onepass            Sync once and exit
   -pidfile FILE       Writes Lsyncds PID into FILE
   -runner FILE        Loads Lsyncds lua part from FILE
   -version            Prints versions and exits
@@ -4726,6 +4728,15 @@ function runner.configure( args, monitors )
 			function
 			( )
 				clSettings.nodaemon = true
+			end
+		},
+
+		onepass =
+		{
+			0,
+			function
+            ( )
+				clSettings.onepass = true
 			end
 		},
 
@@ -4966,6 +4977,11 @@ function runner.initialize( firstTime )
 	if uSettings.nodaemon
 	then
 		lsyncd.configure( 'nodaemon' )
+	end
+
+	if uSettings.onepass
+	then
+		lsyncd.configure( 'onepass' )
 	end
 
 	if uSettings.logfile

--- a/lsyncd.lua
+++ b/lsyncd.lua
@@ -4735,7 +4735,7 @@ function runner.configure( args, monitors )
 		{
 			0,
 			function
-            ( )
+			( )
 				clSettings.onepass = true
 			end
 		},


### PR DESCRIPTION
Hi, 
Thanks for the project, I'm using lsyncd to store config backups on disk, and these need to be restored on initial login - 

There's a bit of complexity in the lua conf files I'm writing (rsync --include/excludes), so rather than write a lua conf parser to do the initial restore sync, I added a -onepass switch to lsyncd which would allow me to sync and immediately exit lsyncd.
Then I can reverse the target and source and continue my normal sync operations -

Fyi I've patched the release in ubuntu 18.04, and have adapted that patch for this git repo (but not tested explicitly) - I hope it is ok.