### PR TITLE
Expose rsync's copy_unsafe_links

### DIFF
--- a/default-rsync.lua
+++ b/default-rsync.lua
@@ -61,6 +61,7 @@ rsync.checkgauge = {
 		compress          =  true,
 		copy_dirlinks     =  true,
 		copy_links        =  true,
+		copy_unsafe_links =  true,
 		cvs_exclude       =  true,
 		dry_run           =  true,
 		executability     =  true,
@@ -585,6 +586,12 @@ rsync.prepare = function
 	if crsync.chown
 	then
 		computed[ computedN ] = '--chown=' .. crsync.chown
+		computedN = computedN  + 1
+	end
+
+	if crsync.copy_unsafe_links
+	then
+		computed[ computedN ] = '--copy-unsafe-links'
 		computedN = computedN  + 1
 	end
 


### PR DESCRIPTION
As per the rsync docs: "This tells rsync to copy the referent of symbolic links that point outside the copied tree. Absolute symlinks are also treated like ordinary files, and so are any symlinks in the source path itself when --relative is used. This option has no additional effect if --copy-links was also specified."