### PR TITLE
Enable ssh._extra args

### DIFF
--- a/default-rsyncssh.lua
+++ b/default-rsyncssh.lua
@@ -553,6 +553,17 @@ rsyncssh.prepare = function
 			computed[ computedN ] = v
 
 			computedN = computedN  + 1
+
+            if not config.rsync._rshIndex
+		    then
+			    config.rsync._rshIndex = #rsyncc + 1
+
+			    rsyncc[ config.rsync._rshIndex ] = '--rsh=ssh'
+		    end
+
+		    rsyncc[ config.rsync._rshIndex ] =
+			    rsyncc[ config.rsync._rshIndex ] .. ' ' .. v
+
 		end
 	end
 


### PR DESCRIPTION
# Description
`ssh._extra` args are currently ignored and never actually appended to the `rsh` arg. This PR addresses this issue (#402 which is closed despite never being properly resolved)

# Testing
Configuration:
```
settings {
        logfile = "/var/log/lsyncd/lsyncd.log",
        statusFile = "/var/log/lsyncd/lsyncd.status",
        insist = true
}

sync {
        default.rsyncssh,
        source = "<source>",
        host = "<host>",
        targetdir = "<destination>",
        excludeFrom = "/etc/lsyncd/lsyncd.exclude",
        delay = 5,
        rsync = {
                verbose = true,
                inplace = true,
                _extra = {
                        "--info=progress2"
                }
        },
        ssh = {
                identityFile = "/home/taylor/.ssh/id_ed25519",
                options = {
                        User = "taylor",
                        StrictHostKeyChecking = "no",
                        Compression = "no",
                        Cipher = "aes256-gcm@openssh.com"
                },
                _extra = {
                        "-T",
                        "-c",
                        "aes256-gcm@openssh.com"
                }
        }
}
```

Results of runing `lsyncd` before changes:

```
/usr/bin/rsync --exclude-from=- --delete --ignore-errors -slvt --info=progress2 --inplace --rsh=ssh -i /home/taylor/.ssh/id_ed25519 -o Compression=no -o User=taylor -o StrictHostKeyChecking=no -o Cipher=aes256-gcm@openssh.com -r <source> <host>:<destination>

ssh -i /home/taylor/.ssh/id_ed25519 -o Compression=no -o User=taylor -o StrictHostKeyChecking=no -o Cipher=aes256-gcm@openssh.com <host> rsync --server -svltre.iLsfxC
```

Results of running `lsyncd` after changes:

```
/usr/bin/rsync --exclude-from=- --delete --ignore-errors -lvts --info=progress2 --inplace --rsh=ssh -i /home/taylor/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o Compression=no -o Cipher=aes256-gcm@openssh.com -o User=taylor -T -c aes256-gcm@openssh.com -r <source> <host>:<destination>

ssh -i /home/taylor/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o Compression=no -o Cipher=aes256-gcm@openssh.com -o User=taylor -T -c aes256-gcm@openssh.com <host> rsync --server -svltre.iLsfxC
```