### PR TITLE
allow deleting excluded files with rsync

### DIFF
--- a/default-rsync.lua
+++ b/default-rsync.lua
@@ -62,6 +62,7 @@ rsync.checkgauge = {
 		copy_dirlinks     =  true,
 		copy_links        =  true,
 		cvs_exclude       =  true,
+		delete_excluded   =  true,
 		dry_run           =  true,
 		executability     =  true,
 		existing          =  true,
@@ -316,7 +317,7 @@ rsync.init = function
 
 	local filters = inlet.hasFilters( ) and inlet.getFilters( )
 
-	local delete   = nil
+	local delete   = {}
 
 	local target   = config.target
 
@@ -334,6 +335,11 @@ rsync.init = function
 	or config.delete == 'startup'
 	then
 		delete = { '--delete', '--ignore-errors' }
+	end
+
+	if config.rsync.delete_excluded == true
+	then
+		table.insert( delete, '--delete-excluded' )
 	end
 
 	if not filters and #excludes == 0


### PR DESCRIPTION
This option can't be added to both init and action, because the rsync exclude mechanism is used to select the files to send, so would delete all non-changed files. It's only relevant during init anyway, as after that no excluded files will be made on the destination.

This is useful to me because it allows excluded files to be easily removed on the destination even if they were not excluded when they were created.

I can make a separate PR with documentation changes if required. Do you think this needs tests?

Thanks!