### PR TITLE
Remove /System/Volumes/Data from fsevent paths on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,9 @@ if( WITH_FSEVENTS )
 	include_directories( ${XNU_DIR} )
 endif( WITH_FSEVENTS )
 
+if ( APPLE )
+	set( LSYNCD_TARGET_APPLE 1 )
+endif ( APPLE )
 
 # generating the config.h file
 configure_file (

--- a/config.h.in
+++ b/config.h.in
@@ -4,3 +4,6 @@
 /* File event notification mechanims available */
 #cmakedefine WITH_INOTIFY 1
 #cmakedefine WITH_FSEVENTS 1
+
+/* OS */
+#cmakedefine LSYNCD_TARGET_APPLE 1

--- a/fsevents.c
+++ b/fsevents.c
@@ -153,6 +153,10 @@ handle_event(lua_State *L, struct kfs_event *event, ssize_t mlen)
 	const char *trg  = NULL;
 	const char *etype = NULL;
 	int isdir = -1;
+#ifdef LSYNCD_TARGET_APPLE \
+	// Since macOS 10.15, fsevent paths are prefixed with this string.
+	const char *const INOTIFY_PREFIX = "/System/Volumes/Data";
+#endif
 
 	if (event->type == FSE_EVENTS_DROPPED) {
 		logstring("Fsevents", "Events dropped!");
@@ -265,6 +269,11 @@ handle_event(lua_State *L, struct kfs_event *event, ssize_t mlen)
 		lua_pushstring(L, etype);
 		lua_pushboolean(L, isdir);
 		l_now(L);
+#ifdef LSYNCD_TARGET_APPLE
+		if (!strncmp(path, INOTIFY_PREFIX, strlen(INOTIFY_PREFIX ))) {
+			path += strlen(INOTIFY_PREFIX);
+		}
+#endif
 		lua_pushstring(L, path);
 		if (trg) {
 			lua_pushstring(L, trg);


### PR DESCRIPTION
Apparently, beginning with macOS 10.15 Catalina, fsevent paths are prefixed
with "/System/Volumes/Data". Remove it to restore event notification feature
on macOS.

Fixes #587