### PR TITLE
fix error - bad binary format (version mismatch)

### DIFF
--- a/cmake/FindLua.cmake
+++ b/cmake/FindLua.cmake
@@ -36,7 +36,7 @@ SET(_POSSIBLE_LUA_INCLUDE include include/lua)
 #SET(_POSSIBLE_LUA_LIBRARY lua)
 
 # Determine possible naming suffixes (there is no standard for this)
-SET(_POSSIBLE_SUFFIXES "52" "5.2" "-5.2" "53" "5.3" "-5.3" "")
+SET(_POSSIBLE_SUFFIXES "54" "5.4" "-5.4" "53" "5.3" "-5.3" "52" "5.2" "-5.2" "")
 
 # Set up possible search names and locations
 FOREACH(_SUFFIX IN LISTS _POSSIBLE_SUFFIXES)


### PR DESCRIPTION
The problem is that the generated make files end up referencing a mix of lua versions
This patch will fix it.