### PR TITLE
Update FAQ entry on scripting

### DIFF
--- a/docs/faq/postscript/index.md
+++ b/docs/faq/postscript/index.md
@@ -39,4 +39,40 @@ sync {
 }
 {% endhighlight %}
 
+If you want to track directories and files passed to rsync command (--include-from) in your bash script, consider that they come via STDIN and NUL delimited chars (rsync is called using --include-from=- --from0).
+
+After calling rsync within your script, STDIN is lost, so if you need it later could do something like this:
+
+{% highlight shell %}
+#!/bin/bash
+
+#create unique temp file to store incoming STDIN
+_TMP_FILE=$(mktemp -q /tmp/lsd-rsync.XXXXXXXXXX || exit 1)
+
+#Set trap to automatically clean up the temp file on exit
+trap 'rm -f -- "$_TMP_FILE"' EXIT
+
+#get last argument (TARGET) and next to last (SOURCE)
+_SOURCE=${@: -2:1}
+_TARGET=${@: -1:1}
+
+#save the current STDIN with \0 (NUL) chars to a file, or we'll lose the original STDIN after calling rsync
+cat - >$_TMP_FILE
+
+#execute rsync with arguments and inject STDIN with NUL delimited chars
+/usr/bin/rsync "$@" <$_TMP_FILE
+
+result=$?
+(
+    # ...
+    # Do anything you need with our saved STDIN as $_TMP_FILE, $_SOURCE, $_TARGET, etc.
+    # ...
+    # for example
+    # replace \0 (NUL) chars with tabs in our stdin saved as a file
+    # sed -i 's/\x0/\t/g' $_TMP_FILE
+    # pass this new file to other script, etc.
+)
+
+{% endhighlight %}
+
 ## [‹‹ back to FAQ index](../)


### PR DESCRIPTION
Update FAQ entry: How can I call a script before or after each rsync operation? Add information about how rsync is called filtering directories and files using STDIN so you have to save it in your bash script to use it after calling rsync