### PR TITLE
Added the 'filter' parameter to the manual

### DIFF
--- a/docs/manual/config/layer4/index.md
+++ b/docs/manual/config/layer4/index.md
@@ -219,6 +219,13 @@ Below is a table of options for the ```rsync``` parameter. Please have a look at
 </td><td> (Lsyncd >= 2.2.0)
 </td></tr>
 
+<tr><td> filter
+</td><td> =
+</td><td> TABLE of STRINGS
+</td><td>
+</td><td> (Lsyncd >= 2.2.3)
+</td></tr>   
+   
  <tr><td> group
 </td><td> =
 </td><td> BOOL


### PR DESCRIPTION
Hi !
Follow up on #696
> The gh-pages branch should not be used anymore and all docs are now in truck. can you change ?

Of course I can change! I had just clicked on the "Improve this page" button in the doc ;)

According to
https://github.com/lsyncd/lsyncd/issues/510#issuecomment-390921153
