### PR TITLE
Fix install of man page

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,11 +89,11 @@ add_custom_command( OUTPUT defaults.out
 )
 
 # the manpage
-add_custom_target( manpage
+add_custom_target( manpage ALL
 	COMMAND ${CMAKE_COMMAND} -E echo "Updating the manpage"
 	COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/man
 	COMMAND a2x --format=manpage ${PROJECT_SOURCE_DIR}/docs/manpage/lsyncd.1.txt -D ${CMAKE_CURRENT_BINARY_DIR}/man
-	DEPENDS docs/manpage/lsyncd.1.txt
+	DEPENDS ${CMAKE_SOURCE_DIR}/docs/manpage/lsyncd.1.txt
 )
 
 # the html documention


### PR DESCRIPTION
When doing the normal build as:
```
mkdir build
cd build
cmake ..
make
sudo make install
```
The `sudo make install` will fail with:
```
CMake Error at cmake_install.cmake:70 (file):
  file INSTALL cannot find
  "/home/jringle/git/lsyncd/lsyncd/build/man/lsyncd.1": No such file or
  directory.
```

This is because the manpage target isn't built by default and the install requires it.